### PR TITLE
Remove extra leading bullet point

### DIFF
--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -41,7 +41,6 @@ to size and configure both RabbitMQ nodes and applications.
 
 This guide provides recommendations in a few areas:
 
- *
  * [Storage](#storage) considerations for node data directories
  * [Networking](#networking)-related recommendations
  * Recommendations related to [virtual hosts, users and permissions](#users-and-permissions)


### PR DESCRIPTION
# What
- I noticed there was an extra bullet point in the production release checklist
<img width="1815" height="1015" alt="image" src="https://github.com/user-attachments/assets/27174525-9bd9-4ba8-8eb5-3129b9ec5266" />

## Changes
- I deleted it.